### PR TITLE
Fix authors filter not applied to historical fetching

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub struct SinkConfig {
 pub enum ProcessorType {
     Passthrough,
     WaitProcessor,
+    Print,
     GeohashFilter {
         #[serde(default)]
         allowed_prefixes: Vec<String>,

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -11,10 +11,12 @@ use crate::config::ProcessorType;
 mod passthrough;
 mod geohash_filter;
 mod wait;
+mod print;
 
 pub use passthrough::PassthroughProcessor;
 pub use geohash_filter::GeohashFilterProcessor;
 pub use wait::WaitProcessor;
+pub use print::PrintProcessor;
 
 /// Trait for processing Nostr events.
 ///
@@ -113,6 +115,7 @@ pub fn create_processor(processor_type: &ProcessorType) -> Box<dyn Processor> {
     match processor_type {
         ProcessorType::Passthrough => Box::new(PassthroughProcessor::new()),
         ProcessorType::WaitProcessor => Box::new(WaitProcessor::default_5s()),
+        ProcessorType::Print => Box::new(PrintProcessor::new()),
         ProcessorType::GeohashFilter { allowed_prefixes } => {
             Box::new(GeohashFilterProcessor::new(allowed_prefixes.clone()))
         }

--- a/src/processor/print.rs
+++ b/src/processor/print.rs
@@ -1,0 +1,62 @@
+use nostr::Event;
+use tracing::info;
+use crate::processor::Processor;
+
+/// A processor that prints event details for debugging purposes.
+///
+/// This processor prints key information about each event including:
+/// - Event ID
+/// - Author (public key)
+/// - Event kind
+/// - Creation timestamp
+/// - Content preview (first 100 characters)
+///
+/// The event is passed through unchanged.
+pub struct PrintProcessor {
+    prefix: String,
+}
+
+impl PrintProcessor {
+    pub fn new() -> Self {
+        Self {
+            prefix: "[PRINT]".to_string(),
+        }
+    }
+
+    pub fn with_prefix(prefix: String) -> Self {
+        Self { prefix }
+    }
+}
+
+impl Default for PrintProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Processor for PrintProcessor {
+    fn process(&self, event: &Event) -> Vec<Event> {
+        let content_preview = if event.content.len() > 100 {
+            format!("{}...", &event.content[..100])
+        } else {
+            event.content.clone()
+        };
+
+        info!(
+            "{} Event: {} | Author: {} | Kind: {} | Time: {} | Content: {}",
+            self.prefix,
+            event.id.to_hex()[..16].to_string() + "...",
+            event.pubkey.to_hex()[..16].to_string() + "...",
+            event.kind.as_u16(),
+            event.created_at.as_u64(),
+            content_preview.replace('\n', " ").replace('\r', "")
+        );
+
+        // Pass through the event unchanged
+        vec![event.clone()]
+    }
+
+    fn name(&self) -> &str {
+        "PrintProcessor"
+    }
+}

--- a/src/relay_router.rs
+++ b/src/relay_router.rs
@@ -404,9 +404,10 @@ impl RelayRouter {
         limit: usize,
         wait_seconds: u64,
     ) -> Result<()> {
-        let fetcher = Fetcher::new(
+        let fetcher = Fetcher::new_with_filters(
             self.source_client.clone(),
             self.sink_clients.clone(),
+            self.config.filters.clone(),
         );
 
         let mut iterations = 0;
@@ -471,9 +472,10 @@ impl RelayRouter {
         };
 
         // Use the fetcher to fill gaps in the range
-        let fetcher = Fetcher::new(
+        let fetcher = Fetcher::new_with_filters(
             self.source_client.clone(),
             self.sink_clients.clone(),
+            self.config.filters.clone(),
         );
 
         let result = {


### PR DESCRIPTION
- Update Fetcher to accept and apply SubFilters for historical event fetching
- Add new_with_filters constructor to pass configured filters to Fetcher
- Apply same filter logic as live streaming using convert_filters_to_nostr
- Handle multiple filters with OR logic and deduplication
- Add PrintProcessor for debugging filtered events
- Update RelayRouter to pass filters to all Fetcher instances

Historical fetching now correctly applies authors, kinds, and tag filters instead of fetching all events and filtering only in live streaming.